### PR TITLE
refactor: rename 'external' to 'isExternal' in CTA properties and update Heading prop name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ dist-ssr
 
 # TypeScript build info
 *.tsbuildinfo
+
+# Claude
+.claude

--- a/src/content/home/hero/slides.ts
+++ b/src/content/home/hero/slides.ts
@@ -8,7 +8,7 @@ export const slides: Slide[] = [
     ctaPrimary: {
       text: "Inscríbete aquí",
       url: "https://asdeporte.com/evento/carrera-san-rafael-balance--2026-qk6/datos-del-evento",
-      external: true,
+      isExternal: true,
     },
   },
   {
@@ -25,7 +25,7 @@ export const slides: Slide[] = [
     ctaPrimary: {
       text: "Descúbre el Balance",
       url: "https://www.youtube.com/@VidaEnBalanceMX",
-      external: true,
+      isExternal: true,
     },
   },
   {
@@ -34,7 +34,7 @@ export const slides: Slide[] = [
     ctaPrimary: {
       text: "Recetas",
       url: "https://www.instagram.com/sanrafaelbalance",
-      external: true
+      isExternal: true,
     },
   },
 ];

--- a/src/interfaces/interfaces.d.ts
+++ b/src/interfaces/interfaces.d.ts
@@ -119,12 +119,12 @@ export interface Slide {
   ctaPrimary: {
     text: string;
     url: string;
-    external?: boolean;
+    isExternal?: boolean;
   };
   ctaSecondary?: {
     text: string;
     url: string;
-    external?: boolean;
+    isExternal?: boolean;
   };
 }
 
@@ -174,7 +174,7 @@ export interface HeadingProps {
   text: string;
   tag: "h1" | "h2";
   id?: string;
-  uppercase?: boolean;
+  isUppercase?: boolean;
   customClassName?: string;
 }
 

--- a/src/ui/components/Heading/Heading.tsx
+++ b/src/ui/components/Heading/Heading.tsx
@@ -6,10 +6,10 @@ export const Heading: FC<HeadingProps> = ({
   text,
   tag,
   id,
-  uppercase = true,
+  isUppercase = true,
   customClassName,
 }) => {
-  const baseClass = `px-4 py-8 sm:py-12 sm:px-6 lg:px-8 bg-linear-to-b from-main to-tertiary${uppercase ? " uppercase" : ""}${customClassName ? ` ${customClassName}` : ""}`;
+  const baseClass = `px-4 py-8 sm:py-12 sm:px-6 lg:px-8 bg-linear-to-b from-main to-tertiary${isUppercase ? " uppercase" : ""}${customClassName ? ` ${customClassName}` : ""}`;
   const textClass = "font-montserrat-bold text-white text-center";
 
   return (

--- a/src/ui/sections/Home/Hero/Hero.tsx
+++ b/src/ui/sections/Home/Hero/Hero.tsx
@@ -77,7 +77,7 @@ export const Hero: FC = () => {
                 {slide.subtitle}
               </p>
               <div className="flex flex-wrap justify-center gap-4">
-                {slide.ctaPrimary.external ? (
+                {slide.ctaPrimary.isExternal ? (
                   <a
                     href={slide.ctaPrimary.url}
                     target="_blank"
@@ -95,7 +95,7 @@ export const Hero: FC = () => {
                   </Link>
                 )}
                 {slide.ctaSecondary && (
-                  slide.ctaSecondary.external ? (
+                  slide.ctaSecondary.isExternal ? (
                     <a
                       href={slide.ctaSecondary.url}
                       target="_blank"


### PR DESCRIPTION
This pull request updates the naming of the `external` property to `isExternal` in CTA button objects throughout the codebase for improved clarity and consistency. It also updates the `uppercase` prop to `isUppercase` in the `Heading` component for better naming convention alignment.

**CTA Button Property Renaming:**

* Changed the `external` property to `isExternal` in all `ctaPrimary` and `ctaSecondary` button objects in the `slides` array in `src/content/home/hero/slides.ts`. [[1]](diffhunk://#diff-ee87c1a006d08edc5977147a4827ce0f646664c0a59f86ad24f250274f4dac87L11-R11) [[2]](diffhunk://#diff-ee87c1a006d08edc5977147a4827ce0f646664c0a59f86ad24f250274f4dac87L28-R28) [[3]](diffhunk://#diff-ee87c1a006d08edc5977147a4827ce0f646664c0a59f86ad24f250274f4dac87L37-R37)
* Updated all usages of the `external` property to `isExternal` in the `Hero` section, ensuring the correct property is referenced for both primary and secondary CTAs in `src/ui/sections/Home/Hero/Hero.tsx`. [[1]](diffhunk://#diff-3b2e0f42f70e30c7d601cb1e2c52dd46fc0528550045f087b2db8238a2b7cb43L80-R80) [[2]](diffhunk://#diff-3b2e0f42f70e30c7d601cb1e2c52dd46fc0528550045f087b2db8238a2b7cb43L98-R98)

**Heading Component Prop Naming:**

* Renamed the `uppercase` prop to `isUppercase` in the `Heading` component for improved clarity and consistency with boolean prop naming conventions in `src/ui/components/Heading/Heading.tsx`.