### PR TITLE
refactor: update slide IDs and remove unused slide data

### DIFF
--- a/src/content/home/hero/slides.ts
+++ b/src/content/home/hero/slides.ts
@@ -3,16 +3,6 @@ import { Slide } from "@interfaces/interfaces";
 export const slides: Slide[] = [
   {
     id: 1,
-    image: "/assets/" + "images/carrera-balance.webp",
-    mobileImage: "/assets/" + "images/carrera-balance-mobile.webp",
-    ctaPrimary: {
-      text: "Inscríbete aquí",
-      url: "https://asdeporte.com/evento/carrera-san-rafael-balance--2026-qk6/datos-del-evento",
-      isExternal: true,
-    },
-  },
-  {
-    id: 2,
     image: "/assets/" + "images/desidete-productos.webp",
     ctaPrimary: {
       text: "Conoce más recetas",
@@ -20,7 +10,7 @@ export const slides: Slide[] = [
     },
   },
   {
-    id: 3,
+    id: 2,
     image: "/assets/" + "images/desidete-cuidados.webp",
     ctaPrimary: {
       text: "Descúbre el Balance",
@@ -29,7 +19,7 @@ export const slides: Slide[] = [
     },
   },
   {
-    id: 4,
+    id: 3,
     image: "/assets/" + "images/desidete-receta.webp",
     ctaPrimary: {
       text: "Recetas",


### PR DESCRIPTION
This pull request updates the `slides` data used for the homepage hero section. The main changes are the removal of the "Carrera Balance" slide and the reordering and renumbering of the remaining slides to ensure sequential IDs.

Slides data updates:

* Removed the slide with `id: 1` for "Carrera Balance" and its associated mobile image and CTA, as well as the slide with `id: 3`.
* Updated the IDs of the remaining slides to be sequential (`id: 1`, `id: 2`, `id: 3`) to reflect the new order after deletions [[1]](diffhunk://#diff-ee87c1a006d08edc5977147a4827ce0f646664c0a59f86ad24f250274f4dac87L6-R13) [[2]](diffhunk://#diff-ee87c1a006d08edc5977147a4827ce0f646664c0a59f86ad24f250274f4dac87L32-R22).